### PR TITLE
update image version of couchdb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
 
   couchdb:
-    image: docker.io/couchdb:2.2
+    image: docker.io/couchdb:2.3
     ports:
       - '${COUCHDB_PORT}:5984'
     environment:


### PR DESCRIPTION
there is a bug with replicator with 2.2 version, may be it is necessary to modify the couch.init with

[replicator]
auth_plugins = couch_replicator_auth_noop